### PR TITLE
Draft: how to make xml output as utf-8?

### DIFF
--- a/libraryapi/pergamum.py
+++ b/libraryapi/pergamum.py
@@ -105,7 +105,7 @@ class Conversor:
 
     @staticmethod
     def convert_dados_marc_to_record(dados_marc: DadosMarc, id: int) -> Record:
-        record = Record(leader="     nam a22      a 4500")
+        record = Record(leader="     nam a22      a 4500", force_utf8=True)
 
         for paragrafo, indicador, descricao in zip(
             dados_marc.paragrafo, dados_marc.indicador, dados_marc.descricao


### PR DESCRIPTION
Quando a gente salva o arquivo da saída xml e executa um `file` nele, o resultado está sendo: 
`ASCII text, with very long lines, with no line terminators`
o resultado deveria ser 
`UTF-8 Unicode text, with very long lines, with no line terminators`

Não achei um jeito de ficar certo, pensei que essa opção pudesse corrigir, mas não percebi mudanças. 
No shell, se executar

`cat arquivodesaída.xml | recode html..UTF-8 > novoarquivo.xml`

Duas coisas são corrigidas: 1) o arquivo fica como UTF-8, 2) entidades nos acentos (Ci&#234;ncia da Informa&#231;&#227;o) são transformadas para acentos "comuns" (Ciência da Informação)

Tem alguma ideia de como corrigir isso?
Exemplo: https://libraryapi-demo.herokuapp.com/pergamum/xml?url=https://pergamum.ufsc.br/pergamum&id=339742
(as entidades só são vistas no código fonte do navegador)