### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ An API to get [MARC (Machine-Readable Cataloging)](https://en.wikipedia.org/wiki
 - Install [Pipenv](https://pipenv.pypa.io/) with pip: `pip install --user pipenv`
 - In Ubuntu 22.04: `export SETUPTOOLS_USE_DISTUTILS=stdlib`
 - `pipenv install --deploy`
-- `uvicorn app.main:app --port 8080`
+- `pipenv shell`
+- `uvicorn app.main:app --port 8080` append `--reload` if you are developing
 
 ## Endpoints and services
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ An API to get [MARC (Machine-Readable Cataloging)](https://en.wikipedia.org/wiki
 ### Locally
 
 - Make sure you have Python 3.10+ installed. You may have to prefix `pip` and `uvicorn` commands with `python3.10 -m` if you have more than one Python interpreter.
-- Install [Pipenv](https://pipenv.pypa.io/)
+- Install [Pipenv](https://pipenv.pypa.io/) with pip: `pip install --user pipenv`
+- In Ubuntu 22.04: `SETUPTOOLS_USE_DISTUTILS=stdlib`
 - `pipenv install --deploy`
 - `uvicorn app.main:app --port 80`
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ An API to get [MARC (Machine-Readable Cataloging)](https://en.wikipedia.org/wiki
 
 - Make sure you have Python 3.10+ installed. You may have to prefix `pip` and `uvicorn` commands with `python3.10 -m` if you have more than one Python interpreter.
 - Install [Pipenv](https://pipenv.pypa.io/) with pip: `pip install --user pipenv`
-- `pipenv install --deploy` (In Ubuntu 22.04: `SETUPTOOLS_USE_DISTUTILS=stdlib pipenv install --deploy`)
-- `uvicorn app.main:app --port 80`
+- In Ubuntu 22.04: `export SETUPTOOLS_USE_DISTUTILS=stdlib`
+- `pipenv install --deploy`
+- `uvicorn app.main:app --port 8080`
 
 ## Endpoints and services
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ An API to get [MARC (Machine-Readable Cataloging)](https://en.wikipedia.org/wiki
 
 - Make sure you have Python 3.10+ installed. You may have to prefix `pip` and `uvicorn` commands with `python3.10 -m` if you have more than one Python interpreter.
 - Install [Pipenv](https://pipenv.pypa.io/) with pip: `pip install --user pipenv`
-- In Ubuntu 22.04: `SETUPTOOLS_USE_DISTUTILS=stdlib`
-- `pipenv install --deploy`
+- `pipenv install --deploy` (In Ubuntu 22.04: `SETUPTOOLS_USE_DISTUTILS=stdlib pipenv install --deploy`)
 - `uvicorn app.main:app --port 80`
 
 ## Endpoints and services


### PR DESCRIPTION
Se usar a instalação com "sudo apt install pipenv" terá uma versão desatualizada que não funcionará, inclusive no Ubuntu 22.04. Por isso é melhor especificar que é para usar a instalação com pip. Outra coisa: no Ubuntu 22.04 está tendo que especificar essa variável SETUPTOOLS_USE_DISTUTILS para usar o pipenv.